### PR TITLE
fix: resolve undefined now() helper function in CanvasFake (#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Methods like `discussionTopics()`, `mediaObjects()`, `quizSubmissions()` now work correctly
   - Case-insensitive method resolution now properly handles all case variations
   - Maintains full backward compatibility with existing snake_case methods
+- **BUG**: Fixed undefined `now()` helper function error in CanvasFake testing utilities
+  - Replaced `now()` with explicit `Carbon::now()` import to prevent "Call to undefined function" errors
+  - Ensures reliable timestamp recording in all Laravel testing environments
+  - Added comprehensive test coverage to prevent regression
+  - Maintains full backward compatibility with existing timestamp functionality
 
 ## [0.1.0] - 2025-01-05
 

--- a/src/Testing/CanvasFake.php
+++ b/src/Testing/CanvasFake.php
@@ -4,6 +4,7 @@ namespace CanvasLMS\Laravel\Testing;
 
 use CanvasLMS\Api\AbstractBaseApi;
 use CanvasLMS\Interfaces\HttpClientInterface;
+use Carbon\Carbon;
 use Mockery;
 use PHPUnit\Framework\Assert;
 
@@ -183,7 +184,7 @@ class CanvasFake
             'method'    => $method,
             'endpoint'  => $endpoint,
             'data'      => $data,
-            'timestamp' => now(),
+            'timestamp' => Carbon::now(),
         ];
     }
 

--- a/tests/Unit/CanvasFakeTest.php
+++ b/tests/Unit/CanvasFakeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use CanvasLMS\Laravel\Testing\CanvasFake;
+use Carbon\Carbon;
 
 beforeEach(function () {
     $this->fake = new CanvasFake;
@@ -44,4 +45,26 @@ test('can clear recorded calls', function () {
     $this->fake->clearRecordedCalls();
 
     expect($this->fake->getRecordedCalls())->toBeEmpty();
+});
+
+test('records timestamps correctly without undefined function error', function () {
+    $this->fake->fake();
+
+    // Use reflection to directly call the protected recordCall method
+    // This verifies that the now() helper issue is fixed
+    $reflection = new ReflectionClass($this->fake);
+    $recordCallMethod = $reflection->getMethod('recordCall');
+    $recordCallMethod->setAccessible(true);
+
+    // This should not throw an "undefined function now()" error
+    $recordCallMethod->invoke($this->fake, 'GET', '/test-endpoint', ['test' => 'data']);
+
+    $calls = $this->fake->getRecordedCalls();
+
+    expect($calls)->toHaveCount(1);
+    expect($calls[0])->toHaveKey('timestamp');
+    expect($calls[0]['timestamp'])->toBeInstanceOf(Carbon::class);
+    expect($calls[0]['method'])->toBe('GET');
+    expect($calls[0]['endpoint'])->toBe('/test-endpoint');
+    expect($calls[0]['data'])->toBe(['test' => 'data']);
 });


### PR DESCRIPTION
## Summary
Fixes a critical bug in the `CanvasFake` testing utilities where the `now()` Laravel helper function was used without proper import, causing potential "Call to undefined function now()" errors in certain test environments.

## Changes Made
- **Fixed undefined function error**: Replaced `now()` with explicit `Carbon::now()` import in `CanvasFake::recordCall()` method
- **Added comprehensive test coverage**: New test using reflection to verify timestamp functionality works correctly
- **Updated CHANGELOG.md**: Documented the bug fix under `[Unreleased]` section
- **Maintained backward compatibility**: No breaking changes to public API

## Files Modified
- `src/Testing/CanvasFake.php` - Added Carbon import and fixed timestamp line
- `tests/Unit/CanvasFakeTest.php` - Added comprehensive test for timestamp functionality
- `CHANGELOG.md` - Documented the bug fix

## Testing
- ✅ All existing tests pass (no regressions)
- ✅ New test specifically validates the fix
- ✅ Laravel Pint formatting checks pass
- ✅ PHPStan static analysis (level 8) passes

## Impact
- **Severity**: Medium - Fixes testing functionality breakage
- **Priority**: P2 - Important for reliable testing
- **Backward Compatibility**: ✅ Fully maintained
- **Performance**: Neutral to positive (eliminates helper layer)
- **Security**: No impact - testing utilities only

## Root Cause
The `now()` helper function is a Laravel-specific helper that may not be available in all Laravel testing contexts, particularly when testing packages in isolation or in environments where Laravel helpers aren't globally registered.

## Solution
Using `Carbon::now()` directly with proper import eliminates dependency on Laravel helper availability while maintaining identical functionality since `now()` internally calls `Carbon::now()` anyway.

## Closes
Closes #3